### PR TITLE
Pr/auth err crash fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,23 @@ specified on future invocations.
 
 ## Attribution
 
-This is a copy of the `f5vpn-client` by [James Y Knight](mailto:foom@fuhm.net)
-hosted [here](https://fuhm.net/software/f5vpn-login/). The only thing that has
-been modified is this README file. (See Git revision history.)
+This is a fork of the `f5vpn-login` project originally hosted
+[here](https://fuhm.net/software/f5vpn-login/), created by
+[James Y Knight](mailto:foom@fuhm.net)
 
 ## License
 
 This software is licensed under GPLv3+. See `COPYING` for more details.
 
 ## Changelog
+
+2015-04-19
+- Bug fix: Prevent program crash on authentication error
+
+2015-03-19
+- **[REI Engineering](https://github.com/reidev) project adoption**
+- Copy project from https://fuhm.net/software/f5vpn-login/ -> https://github.com/reidev/f5vpn-client
+- Format README to markdown
 
 2010-10-15
  - Fix "OverrideGateway0" on non-darwin platforms: on those, pppd cowardly

--- a/f5vpn-login.py
+++ b/f5vpn-login.py
@@ -577,9 +577,13 @@ Content-Length: %(len)d\r
             session = sessid
 
     if session is None:
+
+        # If the response body contains red HTML text, output the error
+        # (Usually authentication errors)
         pat = re.compile('<font color=red>(.*?)</font>', re.MULTILINE)
         for match in pat.finditer(result):
-            sys.stderr.write(match + '\n')
+            err_msg = match.group(1).replace('&nbsp;', '')
+            sys.stderr.write('Error: ' + err_msg + '\n')
             return None
 
         match = re.search("(Challenge: [^<]*)", result)


### PR DESCRIPTION
This fixes program crash on authentication errors, which was caused by attempting to output a regexp `match` object, instead of the match group string.

**Before**

```
$ f5vpn-login foo@snowday.rei.com
password for foo@snowday.rei.com?
Traceback (most recent call last):
  File "/usr/sbin/f5vpn-login.py", line 1201, in <module>
    main(sys.argv)
  File "/usr/sbin/f5vpn-login.py", line 1171, in main
    session = do_login(client_data, host, user, password)
  File "/usr/sbin/f5vpn-login.py", line 582, in do_login
    sys.stderr.write(match + '\n')
TypeError: unsupported operand type(s) for +: '_sre.SRE_Match' and 'str'
```

**After**

```
$ f5vpn-login foo@snowday.rei.com
password for foo@snowday.rei.com?
Error: Either Username or Password do not match!  Please try again.
password for foo@snowday.rei.com?
```
